### PR TITLE
Implement date

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Date and time types for Gleam programs.
 
+## Date Usage
+Dates can be safely created using the `current_date/0` for a UTC date, or `new/3` for a valid time.  A date, or date values, can be validated through `is_valid_date/3` and `is_valid_date_type/1`.
+
+Example
+```gleam
+import date
+
+let current_date = date.current_date()
+
+date.is_valid_date_type(current_date)
+|> expect.equal(_, True)
+
+date.new(2020, 04, 20)
+|> expect.equal(_, Ok(Date(2020, 04, 20)))
+
+
+date.new(-1, -1, -1)
+|> expect.equal(_, Error("Parameters are invalid for a date."))
+
+```
+
 
 ## Quick start
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.6.0"}
+    {gleam_stdlib, "0.7.0"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,6 @@
+{"1.1.0",
+[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.7.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"gleam_stdlib">>, <<"B641FCB5AD56CBD9CDB773C8547BEBA7CA16E85F31AAF9F3FE0F8AFD68AD0DF5">>}]}
+].

--- a/src/gleam/date.gleam
+++ b/src/gleam/date.gleam
@@ -1,0 +1,136 @@
+/// Date is type that is similar in functionality to the Erlang calendar module,
+/// but the types do not directly interface with the calendar module.
+/// To convert an erlang date to a Date type, use `from_tuple/1`
+///
+/// Currently this module defaults to UTC.
+///
+/// Years cannot be abreviated.  Years start from 0 and go up.  So if the year = 93,
+/// it does not refer to 1993.  This is in line with the behavior of Erlang.
+///
+import gleam/result
+import gleam/int
+
+pub type Date {
+  Date(year: Int, month: Int, day: Int)
+}
+
+/// Gets the UTC timestamp.
+///
+/// ## Example
+///
+/// ```gleam
+/// universal_time() = tuple(tuple(year, month, day), tuple(hour, minute, second))
+/// ```
+///
+external fn universal_time() 
+  -> tuple(tuple(Int, Int, Int), tuple(Int, Int, Int)) = "calendar" "universal_time"
+
+/// Gets the current Date.
+///
+/// ## Example
+///
+/// ```gleam
+/// current_date == Date(2020, 04, 22)
+/// ```
+///
+pub fn current_date() -> Date() {
+  let tuple(tuple(year, month, day), _time_tuple) = universal_time()
+  Date(year, month, day)
+}
+
+
+/// Returns the last day of the pass year on the passed month.
+/// Using erlang's calendar module.
+///
+/// ## Examples
+/// ```
+/// last_day_of_the_month(2020, 04) == 30
+/// ```
+///
+pub external fn last_day_of_the_month(year: Int, month: Int) 
+  -> Int = "calendar" "last_day_of_the_month"
+
+/// Checks to see if the current year is a leap year.
+///
+/// ## Examples
+/// ```
+/// is_leap_year(2020) == True
+/// is_leap_year(2019) == False
+/// ```
+///
+pub fn is_leap_year(year: Int) -> Bool{
+  case year % 4 == 0, year % 100 > 0, year % 400 == 0 {
+    True, True, _ -> True
+    _, _, True -> True
+    _, _, _ -> False
+  }
+}
+
+/// Checks to see if the passed date is valid.
+///
+/// ## Examples
+/// ```gleam
+/// let date = Date(12, 31, 2020)
+/// is_valid_date(date) == True
+/// 
+/// let invalid_date = Date(99, 99, -1)
+/// is_valid_date(invalid_date) == False
+/// ```
+///
+pub fn is_valid_date(year: Int, month: Int, day: Int) -> Bool {
+  case year >= 0 && month < 12 && month > 0 && day > 0 {
+    True -> day <= last_day_of_the_month(year, month)
+    False -> False
+  }
+}
+
+/// Checks to see if the passed date is valid.
+///
+/// ## Examples
+/// ```gleam
+/// let date = Date(12, 31, 2020)
+/// is_valid_date(date) == True
+/// 
+/// let invalid_date = Date(99, 99, -1)
+/// is_valid_date(invalid_date) == False
+/// ```
+///
+pub fn is_valid_date_type(date: Date) -> Bool {
+  let Date(year, month, day) = date
+  is_valid_date(year, month, day)
+}
+
+/// Safely create a valid Date.
+///
+/// ## Examples
+/// ```gleam
+/// new(2020, 04, 20) == Ok(Date((2020, 04, 20))
+/// new(-1, -1, -1) == Error("Parameters are invalid for a date.")
+/// ```
+///
+pub fn new(year: Int, month: Int, day: Int) -> Result(Date, String) {
+  let valid_date = is_valid_date(year, month, day)
+
+  case valid_date {
+    True -> Ok(Date(year, month, day))
+    False -> Error("Parameters are invalid for a date.")
+  }
+}
+
+/// Safely create a valid Date from an erlang date.
+///
+/// ## Examples
+/// ```gleam
+/// from_tuple(tuple(2020, 04, 20)) == Ok(Date((2020, 04, 20))
+/// from_tuple(tuple(-1, -1, -1)) == Error("Parameters are invalid for a date.")
+/// ```
+///
+pub fn from_tuple(date_tuple: tuple(Int, Int, Int)) -> Result(Date, String) {
+  let tuple(year, month, day) = date_tuple
+  let valid_date = is_valid_date(year, month, day)
+
+  case valid_date {
+    True -> Ok(Date(year, month, day))
+    False -> Error("Parameters are invalid for a date.")
+  }
+}

--- a/src/gleam/date.gleam
+++ b/src/gleam/date.gleam
@@ -105,7 +105,7 @@ pub fn is_valid_date_type(date: Date) -> Bool {
 /// ## Examples
 /// ```gleam
 /// new(2020, 04, 20) == Ok(Date((2020, 04, 20))
-/// new(-1, -1, -1) == Error("Parameters are invalid for a date.")
+/// new(-1, 11, 29) == Error("Parameters are invalid for a date.")
 /// ```
 ///
 pub fn new(year: Int, month: Int, day: Int) -> Result(Date, String) {

--- a/test/gleam/date_test.gleam
+++ b/test/gleam/date_test.gleam
@@ -1,0 +1,59 @@
+import gleam/date.{Date, new}
+import gleam/expect
+
+pub fn new_test() {
+  date.new(2020, 04, 20)
+  |> expect.equal(_, Ok(Date(2020, 04, 20)))
+
+  date.new(-1, 10, 10)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+
+  date.new(2020, -1, 20)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+
+  date.new(2020, 300, 20)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+
+  date.new(2020, 04, -1)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+
+  date.new(2020, 04, 300)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+}
+
+pub fn from_tuple_test() {
+  tuple(2020, 04, 20)
+  |> date.from_tuple(_)
+  |> expect.equal(_, Ok(Date(2020, 04, 20)))
+
+  tuple(-1, -1, -1)
+  |> date.from_tuple(_)
+  |> expect.equal(_, Error("Parameters are invalid for a date."))
+}
+
+pub fn is_leap_year_test() {
+  date.is_leap_year(2020)
+  |> expect.equal(_, True)
+
+  date.is_leap_year(2019)
+  |> expect.equal(_, False)
+}
+
+pub fn last_day_of_the_month_test() {
+  date.last_day_of_the_month(2020, 04)
+  |> expect.equal(_, 30)
+
+  date.last_day_of_the_month(1993, 12)
+  |> expect.equal(_, 31)
+}
+
+pub fn is_valid_date_test() {
+  Date(2020, 04, 20)
+  |> date.is_valid_date_type(_)
+  |> expect.equal(_, True)
+
+  Date(-1, -1, -1)
+  |> date.is_valid_date_type(_)
+  |> expect.equal(_, False)
+}
+


### PR DESCRIPTION
Here is support for dates.  In the last PR you didn't agree that days / months should be ints and should have their own types, but I think it should be the supported method, Erlang defines them as
```
month() = 1..12
day() = 1..31
```
and using weekdays is limiting and confusing.

Provided is an interface to safely create dates, and to validate dates.  This should be protection enough, and providing safe methods to increment, etc in the future should remove the possibility of invalid dates.

As for month types, not sure if a custom month type makes sense either.  The validation functions take care of valid dates, and comparing ints is faster than atoms.

Now, I think functions to support getting a day / month type from the ints is a great idea.  `date.get_date_of_week(Date(2020, 04, 22)) -> Tuesday`.